### PR TITLE
Run openapi-generator-cli as a github action

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -1,0 +1,35 @@
+name: Update gem from OpenAPI Spec
+
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+  - cron: '0 0 * * 0'
+
+jobs:
+  openapi-generate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up openapi-generator-cli
+      run: wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.9.0/openapi-generator-cli-7.9.0.jar -O openapi-generator-cli.jar
+    - name: OpenAPI Generate
+      run: java -jar openapi-generator-cli.jar generate --input-spec https://raw.githubusercontent.com/kubevirt/kubevirt/refs/heads/main/api/openapi-spec/swagger.json --skip-validate-spec --generator-name ruby --config .openapi-config.json
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        add-paths: |
+          .openapi-generator
+          docs
+          lib
+          README.md
+          spec
+        commit-message: Update kubevirt gem
+        branch: openapi_generate
+        author: ManageIQ Bot <bot@manageiq.org>
+        committer: ManageIQ Bot <bot@manageiq.org>
+        delete-branch: true
+        labels: enhancement
+        push-to-fork: agrare/kubevirt-sdk-ruby
+        title: Update Kubevirt Gem
+        body: Update the kubevirt-sdk-ruby gem from the kubevirt openapi-spec https://github.com/kubevirt/kubevirt/tree/main/api/openapi-spec

--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -37,6 +37,7 @@ jobs:
         committer: ManageIQ Bot <bot@manageiq.org>
         delete-branch: true
         labels: enhancement
-        push-to-fork: agrare/kubevirt-sdk-ruby
+        push-to-fork: miq-bot/kubevirt-sdk-ruby
         title: Update Kubevirt Gem
         body: Update the kubevirt-sdk-ruby gem from the kubevirt openapi-spec https://github.com/kubevirt/kubevirt/tree/main/api/openapi-spec
+        token: ${{ secrets.PR_TOKEN }}

--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -11,8 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up system
+      run: sudo apt install -y xq
+    - id: openapi-version
+      name: Detect openapi-generator-cli version
+      run: |
+        version=`wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/maven-metadata.xml -O - | xq -x "//metadata/versioning/latest"`
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: Set up openapi-generator-cli
-      run: wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.9.0/openapi-generator-cli-7.9.0.jar -O openapi-generator-cli.jar
+      run: wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/${{ steps.openapi-version.outputs.version }}/openapi-generator-cli-${{ steps.openapi-version.outputs.version }}.jar -O openapi-generator-cli.jar
     - name: OpenAPI Generate
       run: java -jar openapi-generator-cli.jar generate --input-spec https://raw.githubusercontent.com/kubevirt/kubevirt/refs/heads/main/api/openapi-spec/swagger.json --skip-validate-spec --generator-name ruby --config .openapi-config.json
     - name: Create Pull Request


### PR DESCRIPTION
Automatically run the openapi-generator-cli on the latest version of the openapi-spec from kubevirt https://raw.githubusercontent.com/kubevirt/kubevirt/refs/heads/main/api/openapi-spec/swagger.json and create a pull request if there are any changes.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
