### PR TITLE
Minor updates to the openapi-generate action

### DIFF
--- a/.github/workflows/openapi-generate.yml
+++ b/.github/workflows/openapi-generate.yml
@@ -36,7 +36,8 @@ jobs:
         committer: ManageIQ Bot <bot@manageiq.org>
         delete-branch: true
         labels: enhancement
+        assignee: agrare
         push-to-fork: miq-bot/kubevirt-sdk-ruby
-        title: Update Kubevirt Gem
+        title: Update kubevirt gem
         body: Update the kubevirt-sdk-ruby gem from the kubevirt openapi-spec https://github.com/kubevirt/kubevirt/tree/main/api/openapi-spec
         token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
@agrare Please review.
- Auto-assign to @agrare 
- Cleanup the PR title (I went with lower case to match the commit message - the other option was to cap the V in KubeVirt, but I like the lower case cause that's the gem's name)