### PR TITLE
Update `.rubocop.yml` reduce warnings in auto-generated code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Layout/EmptyLineAfterMagicComment:
 
 # In a regular class definition, no empty lines around the body.
 Layout/EmptyLinesAroundClassBody:
-  Enabled: true
+  Enabled: false
 
 # In a regular method definition, no empty lines around the body.
 Layout/EmptyLinesAroundMethodBody:
@@ -38,7 +38,7 @@ Layout/EmptyLinesAroundMethodBody:
 
 # In a regular module definition, no empty lines around the body.
 Layout/EmptyLinesAroundModuleBody:
-  Enabled: true
+  Enabled: false
 
 Layout/FirstArgumentIndentation:
   Enabled: true
@@ -58,7 +58,7 @@ Layout/IndentationWidth:
   Enabled: true
 
 Layout/LeadingCommentSpace:
-  Enabled: true
+  Enabled: false
 
 Layout/SpaceAfterColon:
   Enabled: true


### PR DESCRIPTION
This doesn't get rid of all warnings, mainly because I agree with the other issues, e.g.:
```
lib/kubevirt/api/default_api.rb:10170:7: C: [Correctable] Layout/IndentationWidth: Use 2 (not 4) spaces for indentation.
          header_params['Content-Type'] = content_type
      ^^^^
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
